### PR TITLE
Add profile/register routes

### DIFF
--- a/activitytracker/urls.py
+++ b/activitytracker/urls.py
@@ -33,9 +33,11 @@ urlpatterns = [
 
 
     path("dashboard/", dashboard, name="dashboard"),
+    path("register/", register_page, name="register"),
+    path("profile/", profile, name="profile"),
 
 
-    
+
 ]
 
 


### PR DESCRIPTION
## Summary
- add template routes for `register` and `profile`

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2bd7b8c8327943af53446e19bdb